### PR TITLE
Add shebang to entry file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const fs = require('fs-extra')
 const args = require('minimist')(process.argv.slice(2))
 


### PR DESCRIPTION
Running the cli was resulting in a shell syntax error:

`wordpress-gatsby-migrater: line 1: syntax error near unexpected token ``('`

By adding the shebang, and pointing unix to run this under node, I no longer receive this error.